### PR TITLE
Update dependencies to fix security issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,22 +15,22 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-all</artifactId>
-                <version>4.1.115.Final</version>
+                <version>4.1.118.Final</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-java</artifactId>
-                <version>3.25.5</version>
+                <version>3.25.6</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>33.3.1-jre</version>
+                <version>33.4.0-jre</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>2.18.1</version>
+                <version>2.18.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -40,7 +40,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.17.0</version>
+                <version>2.18.0</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Updated `pom.xml` dependency versions for Netty, Protobuf, Guava, Jackson, and Commons-IO to stable recent releases to address known vulnerabilities and resolve Dependabot alerts.

---
*PR created automatically by Jules for task [7831141650954504547](https://jules.google.com/task/7831141650954504547) started by @pradeeban*