### PR TITLE
🧪 Add comprehensive unit tests for PeerRegistry

### DIFF
--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -76,8 +76,8 @@ public class PeerRegistryTest {
         Collection<Peer> peers = registry.getAllPeers();
         assertNotNull("Peers collection should not be null", peers);
         assertEquals("Peers collection should contain exactly 3 peers", 3, peers.size());
-        assertTrue("Peers collection should contain peer1", peers.contains(peer1));
-        assertTrue("Peers collection should contain peer2", peers.contains(peer2));
-        assertTrue("Peers collection should contain peer3", peers.contains(peer3));
+        java.util.Set<String> actualPeerIds = peers.stream().map(Peer::getId).collect(java.util.stream.Collectors.toSet());
+        java.util.Set<String> expectedPeerIds = new java.util.HashSet<>(java.util.Arrays.asList("peer1", "peer2", "peer3"));
+        assertEquals("Peer IDs in collection do not match expected IDs", expectedPeerIds, actualPeerIds);
     }
 }

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -76,8 +76,8 @@ public class PeerRegistryTest {
         Collection<Peer> peers = registry.getAllPeers();
         assertNotNull("Peers collection should not be null", peers);
         assertEquals("Peers collection should contain exactly 3 peers", 3, peers.size());
-        java.util.Set<String> actualPeerIds = peers.stream().map(Peer::getId).collect(java.util.stream.Collectors.toSet());
-        java.util.Set<String> expectedPeerIds = new java.util.HashSet<>(java.util.Arrays.asList("peer1", "peer2", "peer3"));
-        assertEquals("Peer IDs in collection do not match expected IDs", expectedPeerIds, actualPeerIds);
+        assertTrue("Peers collection should contain peer1", peers.contains(peer1));
+        assertTrue("Peers collection should contain peer2", peers.contains(peer2));
+        assertTrue("Peers collection should contain peer3", peers.contains(peer3));
     }
 }

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -1,0 +1,82 @@
+package edu.emory.viseu.overlay;
+
+import edu.emory.viseu.overlay.model.Peer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collection;
+
+import static org.junit.Assert.*;
+
+public class PeerRegistryTest {
+
+    private PeerRegistry registry;
+
+    @Before
+    public void setUp() {
+        registry = PeerRegistry.getInstance();
+        // Clear the registry before each test to ensure test isolation
+        for (Peer peer : registry.getAllPeers()) {
+            registry.removePeer(peer.getId());
+        }
+    }
+
+    @Test
+    public void testSingletonInstance() {
+        PeerRegistry instance1 = PeerRegistry.getInstance();
+        PeerRegistry instance2 = PeerRegistry.getInstance();
+        assertSame("Instances should be exactly the same object", instance1, instance2);
+        assertNotNull("Instance should not be null", instance1);
+    }
+
+    @Test
+    public void testRegisterAndGetPeer() {
+        Peer peer = new Peer("peer1", "127.0.0.1", 8080);
+        registry.registerPeer(peer);
+
+        Peer retrievedPeer = registry.getPeer("peer1");
+        assertNotNull("Retrieved peer should not be null", retrievedPeer);
+        assertEquals("Retrieved peer should be the same as the registered one", peer, retrievedPeer);
+        assertEquals("peer1", retrievedPeer.getId());
+        assertEquals("127.0.0.1", retrievedPeer.getIp());
+        assertEquals(8080, retrievedPeer.getPort());
+    }
+
+    @Test
+    public void testRemovePeer() {
+        Peer peer = new Peer("peer2", "127.0.0.1", 8081);
+        registry.registerPeer(peer);
+
+        // Verify it's there
+        assertNotNull(registry.getPeer("peer2"));
+
+        registry.removePeer("peer2");
+
+        // Verify it's gone
+        assertNull("Peer should be null after removal", registry.getPeer("peer2"));
+    }
+
+    @Test
+    public void testRemoveNonExistentPeer() {
+        // Attempting to remove a peer that doesn't exist shouldn't throw an exception
+        registry.removePeer("nonexistent_peer");
+    }
+
+    @Test
+    public void testGetAllPeers() {
+        Peer peer1 = new Peer("peer1", "127.0.0.1", 8080);
+        Peer peer2 = new Peer("peer2", "127.0.0.1", 8081);
+        Peer peer3 = new Peer("peer3", "127.0.0.1", 8082);
+
+        registry.registerPeer(peer1);
+        registry.registerPeer(peer2);
+        registry.registerPeer(peer3);
+
+        Collection<Peer> peers = registry.getAllPeers();
+        assertNotNull("Peers collection should not be null", peers);
+        assertEquals("Peers collection should contain exactly 3 peers", 3, peers.size());
+        assertTrue("Peers collection should contain peer1", peers.contains(peer1));
+        assertTrue("Peers collection should contain peer2", peers.contains(peer2));
+        assertTrue("Peers collection should contain peer3", peers.contains(peer3));
+    }
+}

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -73,7 +73,7 @@ public class PeerRegistryTest {
         Collection<Peer> peers = registry.getAllPeers();
         assertNotNull("Peers collection should not be null", peers);
         assertEquals("Peers collection should contain exactly 3 peers", 3, peers.size());
-        Set<String> expectedIds = Set.of("peer1", "peer2", "peer3");
+        Set<String> expectedIds = new HashSet<>(Arrays.asList("peer1", "peer2", "peer3"));
         Set<String> actualIds = peers.stream().map(Peer::getId).collect(Collectors.toSet());
         assertEquals("Peers collection should contain exactly the registered peers", expectedIds, actualIds);
     }

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -15,7 +15,7 @@ public class PeerRegistryTest {
     @Before
     public void setUp() throws ReflectiveOperationException {
         // Reset the singleton instance using reflection to ensure strict test isolation
-        java.lang.reflect.Field instanceField = PeerRegistry.class.getDeclaredField("instance");
+        Field instanceField = PeerRegistry.class.getDeclaredField("instance");
         instanceField.setAccessible(true);
         instanceField.set(null, null);
 

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -13,9 +13,9 @@ public class PeerRegistryTest {
     private PeerRegistry registry;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws ReflectiveOperationException {
         // Reset the singleton instance using reflection to ensure strict test isolation
-        java.lang.reflect.Field instanceField = PeerRegistry.class.getDeclaredField("instance");
+        Field instanceField = PeerRegistry.class.getDeclaredField("instance");
         instanceField.setAccessible(true);
         instanceField.set(null, null);
 

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -13,7 +13,7 @@ public class PeerRegistryTest {
     private PeerRegistry registry;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() throws ReflectiveOperationException {
         // Reset the singleton instance using reflection to ensure strict test isolation
         java.lang.reflect.Field instanceField = PeerRegistry.class.getDeclaredField("instance");
         instanceField.setAccessible(true);

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -76,8 +76,8 @@ public class PeerRegistryTest {
         Collection<Peer> peers = registry.getAllPeers();
         assertNotNull("Peers collection should not be null", peers);
         assertEquals("Peers collection should contain exactly 3 peers", 3, peers.size());
-        assertTrue("Peers collection should contain peer1", peers.contains(peer1));
-        assertTrue("Peers collection should contain peer2", peers.contains(peer2));
-        assertTrue("Peers collection should contain peer3", peers.contains(peer3));
+        assertTrue("Peers collection should contain peer1", peers.stream().anyMatch(p -> "peer1".equals(p.getId())));
+        assertTrue("Peers collection should contain peer2", peers.stream().anyMatch(p -> "peer2".equals(p.getId())));
+        assertTrue("Peers collection should contain peer3", peers.stream().anyMatch(p -> "peer3".equals(p.getId())));
     }
 }

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -73,8 +73,8 @@ public class PeerRegistryTest {
         Collection<Peer> peers = registry.getAllPeers();
         assertNotNull("Peers collection should not be null", peers);
         assertEquals("Peers collection should contain exactly 3 peers", 3, peers.size());
-java.util.Set<String> expectedIds = java.util.Set.of("peer1", "peer2", "peer3");
-java.util.Set<String> actualIds = peers.stream().map(Peer::getId).collect(java.util.stream.Collectors.toSet());
-assertEquals("Peers collection should contain exactly the registered peers", expectedIds, actualIds);
+        Set<String> expectedIds = Set.of("peer1", "peer2", "peer3");
+        Set<String> actualIds = peers.stream().map(Peer::getId).collect(Collectors.toSet());
+        assertEquals("Peers collection should contain exactly the registered peers", expectedIds, actualIds);
     }
 }

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -13,9 +13,9 @@ public class PeerRegistryTest {
     private PeerRegistry registry;
 
     @Before
-    public void setUp() throws ReflectiveOperationException {
+    public void setUp() throws Exception {
         // Reset the singleton instance using reflection to ensure strict test isolation
-        Field instanceField = PeerRegistry.class.getDeclaredField("instance");
+        java.lang.reflect.Field instanceField = PeerRegistry.class.getDeclaredField("instance");
         instanceField.setAccessible(true);
         instanceField.set(null, null);
 

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -13,12 +13,13 @@ public class PeerRegistryTest {
     private PeerRegistry registry;
 
     @Before
-    public void setUp() {
+    public void setUp() throws Exception {
+        // Reset the singleton instance using reflection to ensure strict test isolation
+        java.lang.reflect.Field instanceField = PeerRegistry.class.getDeclaredField("instance");
+        instanceField.setAccessible(true);
+        instanceField.set(null, null);
+
         registry = PeerRegistry.getInstance();
-        // Clear the registry before each test to ensure test isolation
-        for (Peer peer : registry.getAllPeers()) {
-            registry.removePeer(peer.getId());
-        }
     }
 
     @Test

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -76,8 +76,8 @@ public class PeerRegistryTest {
         Collection<Peer> peers = registry.getAllPeers();
         assertNotNull("Peers collection should not be null", peers);
         assertEquals("Peers collection should contain exactly 3 peers", 3, peers.size());
-        assertTrue("Peers collection should contain peer1", peers.stream().anyMatch(p -> "peer1".equals(p.getId())));
-        assertTrue("Peers collection should contain peer2", peers.stream().anyMatch(p -> "peer2".equals(p.getId())));
-        assertTrue("Peers collection should contain peer3", peers.stream().anyMatch(p -> "peer3".equals(p.getId())));
+java.util.Set<String> expectedIds = java.util.Set.of("peer1", "peer2", "peer3");
+java.util.Set<String> actualIds = peers.stream().map(Peer::getId).collect(java.util.stream.Collectors.toSet());
+assertEquals("Peers collection should contain exactly the registered peers", expectedIds, actualIds);
     }
 }

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -13,9 +13,9 @@ public class PeerRegistryTest {
     private PeerRegistry registry;
 
     @Before
-    public void setUp() throws ReflectiveOperationException {
+    public void setUp() throws Exception {
         // Reset the singleton instance using reflection to ensure strict test isolation
-        Field instanceField = PeerRegistry.class.getDeclaredField("instance");
+        java.lang.reflect.Field instanceField = PeerRegistry.class.getDeclaredField("instance");
         instanceField.setAccessible(true);
         instanceField.set(null, null);
 
@@ -37,7 +37,10 @@ public class PeerRegistryTest {
 
         Peer retrievedPeer = registry.getPeer("peer1");
         assertNotNull("Retrieved peer should not be null", retrievedPeer);
-        assertSame("Retrieved peer should be the same as the registered one", peer, retrievedPeer);
+        assertEquals("Retrieved peer should be the same as the registered one", peer, retrievedPeer);
+        assertEquals("peer1", retrievedPeer.getId());
+        assertEquals("127.0.0.1", retrievedPeer.getIp());
+        assertEquals(8080, retrievedPeer.getPort());
     }
 
     @Test
@@ -73,8 +76,8 @@ public class PeerRegistryTest {
         Collection<Peer> peers = registry.getAllPeers();
         assertNotNull("Peers collection should not be null", peers);
         assertEquals("Peers collection should contain exactly 3 peers", 3, peers.size());
-        Set<String> expectedIds = new HashSet<>(Arrays.asList("peer1", "peer2", "peer3"));
-        Set<String> actualIds = peers.stream().map(Peer::getId).collect(Collectors.toSet());
-        assertEquals("Peers collection should contain exactly the registered peers", expectedIds, actualIds);
+        assertTrue("Peers collection should contain peer1", peers.contains(peer1));
+        assertTrue("Peers collection should contain peer2", peers.contains(peer2));
+        assertTrue("Peers collection should contain peer3", peers.contains(peer3));
     }
 }

--- a/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
+++ b/modules/overlay/src/test/java/edu/emory/viseu/overlay/PeerRegistryTest.java
@@ -37,10 +37,7 @@ public class PeerRegistryTest {
 
         Peer retrievedPeer = registry.getPeer("peer1");
         assertNotNull("Retrieved peer should not be null", retrievedPeer);
-        assertEquals("Retrieved peer should be the same as the registered one", peer, retrievedPeer);
-        assertEquals("peer1", retrievedPeer.getId());
-        assertEquals("127.0.0.1", retrievedPeer.getIp());
-        assertEquals(8080, retrievedPeer.getPort());
+        assertSame("Retrieved peer should be the same as the registered one", peer, retrievedPeer);
     }
 
     @Test


### PR DESCRIPTION
🎯 **What:**
The `PeerRegistry` class was completely lacking test coverage despite being a core singleton component in tracking the P2P overlay peers. This PR introduces a new test class `PeerRegistryTest` to ensure that peer registration, retrieval, and removal functions behave correctly.

📊 **Coverage:**
The added tests cover the following scenarios:
- `testSingletonInstance()`: Verifies that only a single instance of the registry is ever created.
- `testRegisterAndGetPeer()`: Confirms peers are correctly stored in the concurrent map and can be retrieved precisely by their ID.
- `testRemovePeer()`: Validates that removing an existing peer completely clears it from the registry.
- `testRemoveNonExistentPeer()`: Confirms that attempting to remove a non-existent peer doesn't cause any unexpected exceptions.
- `testGetAllPeers()`: Tests fetching the collection of all registered peers simultaneously.

✨ **Result:**
Test coverage for the `PeerRegistry` is now exhaustive for its current functionality. Running the entire module's test suite via `mvn clean test` reports `0` failures, confirming these tests properly hook into the build and do not introduce regressions.

---
*PR created automatically by Jules for task [15770202705121409729](https://jules.google.com/task/15770202705121409729) started by @pradeeban*