### PR TITLE
Exclude listenablefuture to fix maven-dependency-submission-action 500 error

### DIFF
--- a/modules/overlay/pom.xml
+++ b/modules/overlay/pom.xml
@@ -33,6 +33,12 @@
             <groupId>org.hyperledger.fabric</groupId>
             <artifactId>fabric-gateway-java</artifactId>
             <version>2.2.9</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>listenablefuture</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Exclude `com.google.guava:listenablefuture` from the `org.hyperledger.fabric:fabric-gateway-java` dependency block in `modules/overlay/pom.xml`.

The `9999.0-empty-to-avoid-conflict-with-guava` version string causes the GitHub API (specifically the `advanced-security/maven-dependency-submission-action`) to throw a 500 error due to JSON parsing issues when creating a dependency graph snapshot. Since this dependency is empty, explicitly excluding it avoids the parsing error while maintaining the integrity of the project.

---
*PR created automatically by Jules for task [9329380273473720750](https://jules.google.com/task/9329380273473720750) started by @pradeeban*